### PR TITLE
Update cards_autodetect

### DIFF
--- a/cards_autodetect
+++ b/cards_autodetect
@@ -144,6 +144,11 @@ if ( echo $CARDS_LINE_2 | grep -q "Native Instruments Audio 6 DJ" ) || ( echo $C
        sudo cp /usr/share/pideck/T6.asound.conf /etc/asound.conf
 fi
 
+if ( echo $CARDS_LINE_2 | grep -q "DIGITAL JOCKEY-INTERFACE" ) || ( echo $CARDS_LINE_1 | grep -q "DIGITAL JOCKEY-INTERFACE" ); then
+       XCARD="-a plughw:JOCKEYINTERFACE"
+       RCARD="plughw:JOCKEYINTERFACE"
+fi
+
 echo "            "
 echo "Using "$XCARD" with" $BUFFER"ms Buffer"
 echo "            "


### PR DESCRIPTION
Added DIGITAL JOCKEY-INTERFACE from Reloop
The changes made are working BUT
having two supported sound cards line 110 (as from the original file) show this behaviour:
        

> FOUND audioinjector-pi-soundcard
>FOUND DIGITAL JOCKEY-INTERFACE

>number of supported cards found: 2
>./cards_autodetect: line 110: 04 < 08: value too great for base (error token is "08")
>./cards_autodetect: line 110: 16 < 08: value too great for base (error token is "08")

