### PR TITLE
Simple HTTP server to remotely load tracks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
-debian/.debhelper
-debian/files
-debian/pideck*
+/debian/.debhelper
+/debian/files
+/debian/pideck*
+/pideck_*.deb
+/debian/debhelper-build-stamp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM debian:stretch
+RUN apt-get update && apt-get install -y dpkg-dev dh-make

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Build the package using:
 dpkg-buildpackage -aarmhf -uc -us -b
 ```
 
+Alternatively, if `docker` is installed:
+
+```sh
+make -Bf docker.Makefile
+```
+
 Please see [Soundcard status](soundcards.md) for tips on which soundcard(s) to use with your PiDeck. Your help confirming which soundcards work for you would be appreciated.
 
 For keyboard shortcuts please see [Keyboard control](keyboard_control.md).

--- a/debian/install
+++ b/debian/install
@@ -15,4 +15,5 @@ sup_cards.conf usr/share/pideck
 soundcard-setup.service etc/systemd/system
 touchscreen_controls_L usr/share/pideck
 touchscreen_controls_R usr/share/pideck
+track-upload usr/share/pideck
 xwax_rescan usr/share/pideck

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -1,0 +1,5 @@
+pideck_0.2-4_armhf.deb :
+	docker build -t pideck-dev .
+	docker run -v $$(pwd):/root/src -w /root/src pideck-dev \
+	bash -c "dpkg-buildpackage -aarmhf -uc -us -b && \
+	         mv ../$@ ."

--- a/pideck
+++ b/pideck
@@ -60,3 +60,8 @@ else
      echo -e "\nNow we are ready to start xwax:\n"
      xwax -i $IMPORT -s $SCAN -k -q 89 -g 630x480 --no-decor $DICER -m $BUFFER -r $SAMPLERATE $XCARD $LIBRARY &
 fi
+
+# start server for remote control
+if ! ss -tulpn | grep -q :8080; then
+    /usr/share/pideck/track-upload &
+fi

--- a/track-upload
+++ b/track-upload
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+
+import cgi
+import tempfile
+import traceback
+from os import curdir, sep, chmod
+from subprocess import call
+from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+
+class TrackUpload(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == '/':
+            self.send_response(200)
+            self.send_header('Content-type', 'text/html')
+            self.end_headers()
+            self.wfile.write('''<html>
+  <body>
+    <form method="POST" enctype="multipart/form-data" action="http://127.0.0.1/">
+      <label for="track">Select a file:</label>
+      <input type="file" name="track" id="track"/>
+      <input type="submit" value="Upload"/>
+    </form>
+  </body>
+</html>''')
+            return
+        else:
+            self.send_error(404)
+    def do_POST(self):
+        try:
+            ctype, pdict = cgi.parse_header(self.headers.getheader('content-type'))
+            if ctype == 'multipart/form-data':
+                query = cgi.parse_multipart(self.rfile, pdict)
+            data = query.get('track')[0]
+            if not data:
+                self.send_error(400, 'No file selected!');
+            else:
+                f = tempfile.NamedTemporaryFile('w', delete=False)
+                print 'Saving track to ' + f.name
+                f.write(data)
+                f.close()
+                chmod(f.name, 0o644)
+                print 'Calling xwax-client'
+                command = ['xwax-client', 'localhost', 'load_track', '0', f.name, 'some artist', 'some track']
+                print command
+                call(command)
+                self.send_response(301)
+                self.end_headers()
+                self.wfile.write('<html>Track was loaded!</html>');
+        except:
+            traceback.print_exc()
+            self.send_error(500, 'Something went wrong...');
+
+def main():
+    try:
+        print 'Starting HTTP server for uploading tracks...'
+        # need sudo to bind to port 80
+        port = 8080
+        server = HTTPServer(('', port), TrackUpload)
+        print 'Server up. Listening on http://localhost' + ('' if port == 80  else ':' + str(port))
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print 'Shutting down server...'
+        server.socket.close()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This is a very simple HTTP server, written in python, to remotely load tracks. I use it to upload YouTube songs to my record player, with [this bash script](https://gist.github.com/bertfrees/1a375001fbae2760ccb4ad335a600bfe). It requires a special version of xwax with integrated [OSC server](https://en.wikipedia.org/wiki/Open_Sound_Control). You can find this version of xwax [here](https://github.com/pideck/xwax/compare/pideck...bertfrees:osc). I haven't written it myself, I just rebased [an existing branch](https://github.com/oligau/xwax-1.5-osc) onto the latest tip. The Debian package is built [here](https://github.com/pideck/xwax-packaging/compare/master...bertfrees:osc). I'm also working on a Firefox plugin to load tracks directly from within the YouTube site with a simple mouse click.