### PR TITLE
fix(touch-ctrl): improves responsiveness of buttons

### DIFF
--- a/touchscreen_controls_L
+++ b/touchscreen_controls_L
@@ -139,17 +139,17 @@ def make_window():
     box = gtk.VButtonBox()
 
     btn = gtk.Button("LOAD")
-    btn.connect("clicked", load_button)
+    btn.connect("pressed", load_button)
     btn.set_size_request(50, 68)
     box.add(btn)
 
     btn = gtk.Button("CUE")
-    btn.connect("clicked", cue_button)
+    btn.connect("pressed", cue_button)
     btn.set_size_request(50, 68)
     box.add(btn)
 
     btn = gtk.Button("TIMECD")
-    btn.connect("clicked", timecode_button)
+    btn.connect("pressed", timecode_button)
     btn.set_size_request(50, 68)
     box.add(btn)
 
@@ -188,12 +188,12 @@ def make_window():
 
     if results.card == 'traktora6' or results.card == 'twindeck' or results.card == 'ranesl1':
         btn = gtk.Button("SORT")
-        btn.connect("clicked", sort_button)
+        btn.connect("pressed", sort_button)
         btn.set_size_request(50, 68)
         box.add(btn)
 
         btn = gtk.Button("RESCAN")
-        btn.connect("clicked", rescan_button)
+        btn.connect("pressed", rescan_button)
         btn.set_size_request(50, 68)
         box.add(btn)
 

--- a/touchscreen_controls_R
+++ b/touchscreen_controls_R
@@ -146,17 +146,17 @@ def make_window():
 
     if results.card == 'traktora6' or results.card == 'twindeck' or results.card == 'ranesl1':
         btn = gtk.Button("LOAD")
-        btn.connect("clicked", load_button)
+        btn.connect("pressed", load_button)
         btn.set_size_request(50, 68)
         box.add(btn)
 
         btn = gtk.Button("CUE")
-        btn.connect("clicked", cue_button)
+        btn.connect("pressed", cue_button)
         btn.set_size_request(50, 68)
         box.add(btn)
 
         btn = gtk.Button("TIMECD")
-        btn.connect("clicked", timecode_button)
+        btn.connect("pressed", timecode_button)
         btn.set_size_request(50, 68)
         box.add(btn)
 
@@ -182,32 +182,32 @@ def make_window():
         box.add(btn)
 
     btn = gtk.Button("PG UP")
-    btn.connect("clicked", pageup_button)
+    btn.connect("pressed", pageup_button)
     btn.set_size_request(50, 68)
     box.add(btn)
 
     btn = gtk.Button("UP")
-    btn.connect("clicked", up_button)
+    btn.connect("pressed", up_button)
     btn.set_size_request(50, 68)
     box.add(btn)
 
     btn = gtk.Button("DOWN")
-    btn.connect("clicked", down_button)
+    btn.connect("pressed", down_button)
     btn.set_size_request(50, 68)
     box.add(btn)
 
     btn = gtk.Button("PG DOWN")
-    btn.connect("clicked", pagedown_button)
+    btn.connect("pressed", pagedown_button)
     box.add(btn)
 
     if results.card != 'traktora6' and results.card != 'twindeck' and results.card != 'ranesl1':
         btn = gtk.Button("SORT")
-        btn.connect("clicked", sort_button)
+        btn.connect("pressed", sort_button)
         btn.set_size_request(50, 68)
         box.add(btn)
 
         btn = gtk.Button("RESCAN")
-        btn.connect("clicked", rescan_button)
+        btn.connect("pressed", rescan_button)
         btn.set_size_request(50, 68)
         box.add(btn)
 


### PR DESCRIPTION
uses "pressed" in favour of "clicked" to act immediately instead of the button going through both the pressed and released states.

this may not be entirely desirable for users who are actually using the release for a tight cue, but I imagine that won't be many, if any.

happy for this to be turned into an issue and/or discussion to happen in this PR, potentially to make this a config setting on how the buttons act.