### PR TITLE
added udev rule for xone32c

### DIFF
--- a/99-xone.rules
+++ b/99-xone.rules
@@ -1,0 +1,1 @@
+ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="22f0", ATTR{idProduct}=="0008", ATTR{bConfigurationValue}="2"

--- a/debian/install
+++ b/debian/install
@@ -16,3 +16,4 @@ soundcard-setup.service etc/systemd/system
 touchscreen_controls_L usr/share/pideck
 touchscreen_controls_R usr/share/pideck
 xwax_rescan usr/share/pideck
+99-xone.rules etc/udev/rules.d


### PR DESCRIPTION
hello.maybe you can help me.with udev entry i can't get my xone 23 c with 4/4 in-/output to run on my rpi4